### PR TITLE
add lychee link check to housekeeper

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -17,7 +17,6 @@ jobs:
       - name: check links
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-        with:
           args: --verbose --no-progress --exclude-path 'migrated_content.md' '*.md' '**/*.md'
           fail: true
         env:

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -1,0 +1,25 @@
+name: housekeeping
+on:
+  # Run daily at 7:00
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+# pin the github actions to specific release versions
+jobs:
+  link_checker:
+    name: link checker
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v3.5.2
+
+      - name: check links
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+        with:
+          args: --verbose --no-progress --exclude-path 'migrated_content.md' '*.md' '**/*.md'
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# ignore false positives from the link checker housekeeper
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-Github repo for OWASP project page for SecurityRAT
+Github repo for [OWASP project page][project] for SecurityRAT
+
+SecurityRAT [documentation][docs].
+
+## Online Demo
+
+Check out our brand-new online demo:
+
+**url**: [SecurityRAT][demo]
+
+**username**: demo
+
+**password**: SecurityRATdemo10!
+
+You can try it out with the demo version and can modify/add/delete requirements. The demo version will be resetted every 24 hours (CEST).
+
+
+[demo]: https://securityrat.org
+[docs]: https://securityrat.github.io
+[project]: https://owasp.org/www-project-securityrat/
+


### PR DESCRIPTION
This pr creates a new workflow that is run daily: `housekeeper.yaml`
The housekeeper runs a lychee action which checks all the links in the project for `.md` but excludes the file`migrated_content.md` because this has many broken links and is no longer used
The workflow will fail if there is a broken link, for example to https://securityrat.org/

The README.md file has been expanded to show the demo and docs links, there is no particular need to do this, it just looks nice

closes issue #6